### PR TITLE
added consent config variable

### DIFF
--- a/site_persistence_file.json
+++ b/site_persistence_file.json
@@ -418,6 +418,7 @@
         "REQUIRED_CORE_DATA = ['org', 'tou']\n", 
         "SHOW_EXPLORE = False\n", 
         "SHOW_PROFILE_MACROS = ['indigenous', 'pca_localized']\n", 
+        "CONSENT_EDIT_PERMISSIBLE_ROLES=['provider', 'admin']\n",
         "SHOW_WELCOME = True\n", 
         "\n", 
         "# Assessment Engine configuration\n", 


### PR DESCRIPTION
Addressing this story: https://www.pivotaltracker.com/n/projects/1225464
where roles allowed to edit consents are different between Eproms and Truenth
In Eproms, a provider is allowed to edit consents (as opposed to Truenth)