### PR TITLE
add config variable to show filter by orgs UI in Eproms, ONLY

### DIFF
--- a/site_persistence_file.json
+++ b/site_persistence_file.json
@@ -443,6 +443,7 @@
         "CONSENT_EDIT_PERMISSIBLE_ROLES = ['provider', 'admin']\n",
         "CUSTOM_PATIENT_DETAIL = True\n",
         "SHOW_WELCOME = True\n", 
+        "ALLOW_FILTER_BY_ORGS = True\n",
         "\n", 
         "# Assessment Engine configuration\n", 
         "INSTRUMENTS = [\n", 


### PR DESCRIPTION
The filter by orgs UI should only be viewable in Eproms
Addressing this story: https://www.pivotaltracker.com/story/show/139249273