### PR TITLE
remove filter by orgs configuration variable

### DIFF
--- a/site_persistence_file.json
+++ b/site_persistence_file.json
@@ -443,7 +443,6 @@
         "CONSENT_EDIT_PERMISSIBLE_ROLES = ['provider', 'admin']\n",
         "CUSTOM_PATIENT_DETAIL = True\n",
         "SHOW_WELCOME = True\n", 
-        "ALLOW_FILTER_BY_ORGS = True\n",
         "\n", 
         "# Assessment Engine configuration\n", 
         "INSTRUMENTS = [\n", 


### PR DESCRIPTION
the filter by orgs feature in patients list page is needed in both Eproms and Truenth now, so this variable is no longer needed.