### PR TITLE
Use eproms-specific pw reset email templates

### DIFF
--- a/site_persistence_file.json
+++ b/site_persistence_file.json
@@ -659,6 +659,8 @@
         "REQUIRED_CORE_DATA = ['org', 'tou']\n", 
         "SHOW_EXPLORE = False\n", 
         "SHOW_PROFILE_MACROS = ['race', 'ethnicity', 'language']\n", 
+        "USER_FORGOT_PASSWORD_EMAIL_TEMPLATE = 'flask_user/emails/eproms_forgot_password'\n",
+        "USER_PASSWORD_CHANGED_EMAIL_TEMPLATE = 'flask_user/emails/eproms_password_changed'\n",
         "CONSENT_EDIT_PERMISSIBLE_ROLES = ['staff', 'admin']\n",
         "CUSTOM_PATIENT_DETAIL = True\n",
         "LOCALIZED_AFFILIATE_ORG = 'CRV'\n",


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/144890865

* added in new config settings to site persistence file, to override the default email templates with custom eproms-specific templates