### PR TITLE
Add default en_US locales to eproms US orgs

### DIFF
--- a/site_persistence_file.json
+++ b/site_persistence_file.json
@@ -39,17 +39,7 @@
       }, 
       "resourceType": "Organization", 
       "telecom": [],
-      "extension": [
-        {"url": "http://hl7.org/fhir/valueset/languages",
-          "valueCodeableConcept": {
-            "coding": [
-              {"system": "urn:ietf:bcp:47",
-               "code": "en_US"
-              }
-            ]
-          }
-        }
-      ]
+      "language": "en_US"
     }, 
     {
       "address": [], 
@@ -72,17 +62,7 @@
       }, 
       "resourceType": "Organization", 
       "telecom": [],
-      "extension": [
-        {"url": "http://hl7.org/fhir/valueset/languages",
-          "valueCodeableConcept": {
-            "coding": [
-              {"system": "urn:ietf:bcp:47",
-               "code": "en_US"
-              }
-            ]
-          }
-        }
-      ]
+      "language": "en_US"
     }, 
     {
       "address": [], 
@@ -192,17 +172,7 @@
       }, 
       "resourceType": "Organization", 
       "telecom": [],
-      "extension": [
-        {"url": "http://hl7.org/fhir/valueset/languages",
-          "valueCodeableConcept": {
-            "coding": [
-              {"system": "urn:ietf:bcp:47",
-               "code": "en_US"
-              }
-            ]
-          }
-        }
-      ]
+      "language": "en_US"
     }, 
     {
       "address": [], 
@@ -280,17 +250,7 @@
       }, 
       "resourceType": "Organization", 
       "telecom": [],
-      "extension": [
-        {"url": "http://hl7.org/fhir/valueset/languages",
-          "valueCodeableConcept": {
-            "coding": [
-              {"system": "urn:ietf:bcp:47",
-               "code": "en_US"
-              }
-            ]
-          }
-        }
-      ]
+      "language": "en_US"
     }, 
     {
       "address": [], 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/145362585
https://github.com/uwcirg/true_nth_usa_portal/pull/905

* replace current 'extension' locale settings with 'language' locale setting for US orgs
  * (in other words, instead of having 'en_US' in the general locales list for each org, 'en_US' is now that org's default_locale (relevant for setting user locales during user creation)