### PR TITLE
Hide public-facing Terms footer link in eproms

### DIFF
--- a/site_persistence_file.json
+++ b/site_persistence_file.json
@@ -700,6 +700,7 @@
         "REQUIRED_CORE_DATA = ['org', 'website_terms_of_use', 'subject_website_consent', 'stored_website_consent_form', 'privacy_policy', 'race', 'ethnicity']\n", 
         "SHOW_EXPLORE = False\n", 
         "SHOW_PROFILE_MACROS = ['race', 'ethnicity', 'language']\n", 
+        "SHOW_PUBLIC_TERMS = False\n",
         "USER_FORGOT_PASSWORD_EMAIL_TEMPLATE = 'flask_user/emails/eproms_forgot_password'\n",
         "USER_PASSWORD_CHANGED_EMAIL_TEMPLATE = 'flask_user/emails/eproms_password_changed'\n",
         "CONSENT_EDIT_PERMISSIBLE_ROLES = ['staff', 'admin']\n",


### PR DESCRIPTION
* set `SHOW_PUBLIC_TERMS = False` for eproms, to hide the 'Terms' link in the footer when not logged in