### PR TITLE
Plugging in blank LR document for staff ToU.

### DIFF
--- a/site_persistence_file.json
+++ b/site_persistence_file.json
@@ -603,8 +603,18 @@
       "resourceType": "AppText"
     },
     {
+      "custom_text": "{config[LR_ORIGIN]}/c/portal/truenth/asset/detailed?groupId={config[LR_GROUP]}&version=latest&uuid=d7316b23-b563-0c36-76e4-a3ddd0ea3e81&editorUrl=true",
+      "name": "IRONMAN staff website consent URL",
+      "resourceType": "AppText"
+    },
+    {
       "custom_text": "{config[LR_ORIGIN]}/c/portal/truenth/asset/detailed?groupId={config[LR_GROUP]}&version=latest&uuid=106e46a0-86e8-d61c-7173-1df271180503&editorUrl=true",
       "name": "CRV organization website consent URL",
+      "resourceType": "AppText"
+    },
+    {
+      "custom_text": "{config[LR_ORIGIN]}/c/portal/truenth/asset/detailed?groupId={config[LR_GROUP]}&version=latest&uuid=d7316b23-b563-0c36-76e4-a3ddd0ea3e81&editorUrl=true",
+      "name": "CRV staff website consent URL",
       "resourceType": "AppText"
     },
     {


### PR DESCRIPTION
@mcjustin this should plug in the blank LR content for `staff` with an organization looking up the initial ToU.  Requires https://github.com/uwcirg/true_nth_usa_portal/pull/1033 to function.