### PR TITLE
Add AppText LR URL for invite email when no org

### DIFF
--- a/site_persistence_file.json
+++ b/site_persistence_file.json
@@ -1236,6 +1236,11 @@
       "resourceType": "AppText"
     },
     {
+      "custom_text": "{config[LR_ORIGIN]}/c/portal/truenth/asset/mail?version=latest&uuid=9d2bc012-aca4-975b-6f3c-1c6ddfb66c82",
+      "name": "profileSendEmail invite email",
+      "resourceType": "AppText"
+    },
+    {
       "custom_text": "Report your health on TrueNTH. Email from (clinic name)", 
       "name": "profileSendEmail reminder email_subject", 
       "resourceType": "AppText"


### PR DESCRIPTION
* added apptext entry 'invite email' in situations where user has no org