### PR TITLE
Ironman aua orgs

### DIFF
--- a/site_persistence_file.json
+++ b/site_persistence_file.json
@@ -187,28 +187,6 @@
     }, 
     {
       "address": [], 
-      "id": 21300, 
-      "identifier": [], 
-      "name": "Australian Prostate Cancer Research Centre – Queensland", 
-      "partOf": {
-        "reference": "api/organization/21100"
-      }, 
-      "resourceType": "Organization", 
-      "telecom": []
-    }, 
-    {
-      "address": [], 
-      "id": 21400, 
-      "identifier": [], 
-      "name": "Eastern Health", 
-      "partOf": {
-        "reference": "api/organization/21100"
-      }, 
-      "resourceType": "Organization", 
-      "telecom": []
-    }, 
-    {
-      "address": [], 
       "id": 21200, 
       "identifier": [], 
       "name": "Australia Recruiting Site B", 
@@ -236,6 +214,28 @@
       "name": "AU B Child Site 2", 
       "partOf": {
         "reference": "api/organization/21200"
+      }, 
+      "resourceType": "Organization", 
+      "telecom": []
+    }, 
+    {
+      "address": [], 
+      "id": 21300, 
+      "identifier": [], 
+      "name": "Australian Prostate Cancer Research Centre – Queensland", 
+      "partOf": {
+        "reference": "api/organization/21000"
+      }, 
+      "resourceType": "Organization", 
+      "telecom": []
+    }, 
+    {
+      "address": [], 
+      "id": 21400, 
+      "identifier": [], 
+      "name": "Eastern Health", 
+      "partOf": {
+        "reference": "api/organization/21000"
       }, 
       "resourceType": "Organization", 
       "telecom": []

--- a/site_persistence_file.json
+++ b/site_persistence_file.json
@@ -189,18 +189,7 @@
       "address": [], 
       "id": 21110, 
       "identifier": [], 
-      "name": "AUA Child Site 1", 
-      "partOf": {
-        "reference": "api/organization/21100"
-      }, 
-      "resourceType": "Organization", 
-      "telecom": []
-    }, 
-    {
-      "address": [], 
-      "id": 21120, 
-      "identifier": [], 
-      "name": "AUA Child Site 2", 
+      "name": "Australian Urology Associates (AUA)", 
       "partOf": {
         "reference": "api/organization/21100"
       }, 

--- a/site_persistence_file.json
+++ b/site_persistence_file.json
@@ -178,7 +178,7 @@
       "address": [], 
       "id": 21100, 
       "identifier": [], 
-      "name": "AUA Recruiting Site", 
+      "name": "Australian Urology Associates (AUA)", 
       "partOf": {
         "reference": "api/organization/21000"
       }, 
@@ -187,9 +187,20 @@
     }, 
     {
       "address": [], 
-      "id": 21110, 
+      "id": 21300, 
       "identifier": [], 
-      "name": "Australian Urology Associates (AUA)", 
+      "name": "Australian Prostate Cancer Research Centre – Queensland", 
+      "partOf": {
+        "reference": "api/organization/21100"
+      }, 
+      "resourceType": "Organization", 
+      "telecom": []
+    }, 
+    {
+      "address": [], 
+      "id": 21400, 
+      "identifier": [], 
+      "name": "Eastern Health", 
       "partOf": {
         "reference": "api/organization/21100"
       }, 
@@ -1448,4 +1459,3 @@
   "resourceType": "Bundle", 
   "type": "document"
 }
-


### PR DESCRIPTION
Here's a summary of what this changes. When we do this, we'll need to run the following sql:
update user_organizations set organization_id = 21300 where organization_id = 21110;
update user_organizations set organization_id = 21400 where organization_id = 21120;

IRONMAN UNCHANGED
-Australia (Region/Country Site) UNCHANGED
--AUA Recruiting Site Australian Urology Associates (AUA) (no children, so patients can be added at this level) 21100 RENAME
---AUA Child Site 1 21110 (DELETE will move all users at this org to 21300)
---AUA Child Site 2  21112 (DELETE will move all users at this org to 21400)
--Australian Prostate Cancer Research Centre – Queensland (new; no children, so patients can be added at this level) 21300 NEW
--Eastern Health (new; no children, so patients can be added at this level) 21400 NEW
--Australia Recruiting Site B UNCHANGED
---AU B Child Site 1 UNCHANGED
---AU B Child Site 2 UNCHANGED